### PR TITLE
commented out two unused variables that were tripping up -Werror

### DIFF
--- a/src/kml/engine/kml_file.cc
+++ b/src/kml/engine/kml_file.cc
@@ -38,7 +38,7 @@ using kmlbase::XmlnsId;
 
 namespace kmlengine {
 
-static const char kDefaultXmlns[] = "http://www.opengis.net/kml/2.2";
+// static const char kDefaultXmlns[] = "http://www.opengis.net/kml/2.2";
 static const char kDefaultEncoding[] = "utf-8";
 
 // static

--- a/src/kml/regionator/regionator_util.cc
+++ b/src/kml/regionator/regionator_util.cc
@@ -32,7 +32,7 @@
 
 namespace kmlregionator {
 
-static const int kAlignRegionMaxDepth = 24;
+// static const int kAlignRegionMaxDepth = 24;
 
 using kmldom::AbstractLatLonBoxPtr;
 using kmldom::CoordinatesPtr;


### PR DESCRIPTION
I was trying to compile this on my mac and these unused variables were causing warnings which caused errors when compiling with -Werror.  They appear nowhere else in the code.  Maybe you'd like to delete them?  Either way, commenting them out means that it compiles now.